### PR TITLE
Update wpml-rest-api.php

### DIFF
--- a/wpml-rest-api.php
+++ b/wpml-rest-api.php
@@ -111,5 +111,7 @@ function wpmlrestapi_slug_get_translations( $object, $field_name, $request ) {
  */
 function wpmlrestapi_slug_get_current_locale( $object, $field_name, $request ) {
 	$langInfo = wpml_get_language_information($object);
-	return $langInfo['locale'];
+	if (!is_wp_error($langInfo)) {
+		return $langInfo['locale'];	
+	}
 }


### PR DESCRIPTION
When creating a new post wpml_get_language_information() returns a WP_ERROR object with cannot be used as array. Throws a Fatal error: Uncaught Error: Cannot use object of type WP_Error as array